### PR TITLE
bump to 0.5.0, edition 2024, update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "realflight-bridge"
-version = "0.4.2"
-edition = "2021"
+version = "0.5.0"
+edition = "2024"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 readme = "README.md"
 description = "RealFlightBridge is a Rust library that interfaces with RealFlight Link, enabling external flight controllers to interact with the simulator."
@@ -22,19 +22,19 @@ bench-internals = []
 
 [dependencies]
 uom = { version = "0.37.0", features = ["serde"], optional = true }
-env_logger = "0.11.6"
-log = "0.4.25"
+env_logger = "0.11.8"
+log = "0.4.29"
 crossbeam-channel = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-postcard = { version = "1.1.1", features = ["use-std"] }
-anyhow = "1.0.97"
-clap = "4.5.28"
+postcard = { version = "1.1.3", features = ["use-std"] }
+anyhow = "1.0.100"
+clap = "4.5.54"
 
 [dev-dependencies]
-clap = "4.5.28"
+clap = "4.5.54"
 rand = "0.9"
-criterion = { version = "0.7", features = ["html_reports"] }
-serial_test = "3.2.0"
+criterion = { version = "0.8", features = ["html_reports"] }
+serial_test = "3.3.1"
 approx = "0.5.1"
 
 [[bench]]


### PR DESCRIPTION
- Bump version to 0.5.0
- Update Rust edition to 2024
- Update dependencies to latest versions