### PR TITLE
fix: replace panics with proper error propagation

### DIFF
--- a/src/bin/realflight_bridge_proxy.rs
+++ b/src/bin/realflight_bridge_proxy.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let bind_address = matches.get_one::<String>("bind-address").unwrap();
 
-    let mut server = ProxyServer::new(bind_address);
+    let mut server = ProxyServer::new(bind_address)?;
     server.run()?;
 
     Ok(())

--- a/src/bridge/remote.rs
+++ b/src/bridge/remote.rs
@@ -32,7 +32,7 @@
 //! use realflight_bridge::ProxyServer;
 //!
 //! fn main() -> Result<(), Box<dyn Error>> {
-//!     let mut server = ProxyServer::new("0.0.0.0:8080"); // Normal mode
+//!     let mut server = ProxyServer::new("0.0.0.0:8080")?; // Normal mode
 //!     server.run()?; // Runs indefinitely until an error occurs
 //!     Ok(())
 //! }
@@ -226,7 +226,7 @@ const SIMULATOR_HOST: &str = "127.0.0.1:18083";
 /// use realflight_bridge::ProxyServer;
 ///
 /// fn main() -> Result<(), Box<dyn Error>> {
-///     let mut server = ProxyServer::new("0.0.0.0:8080");
+///     let mut server = ProxyServer::new("0.0.0.0:8080")?;
 ///     server.run()?; // Runs indefinitely until an error occurs
 ///     Ok(())
 /// }
@@ -241,28 +241,34 @@ impl ProxyServer {
     ///
     /// # Arguments
     /// * `bind_address` - The address to bind to (e.g., "0.0.0.0:8080").
-    pub fn new(bind_address: &str) -> Self {
-        let listener = TcpListener::bind(bind_address).unwrap();
-        ProxyServer {
+    ///
+    /// # Returns
+    /// A `Result` containing the server instance or an I/O error if binding fails.
+    pub fn new(bind_address: &str) -> std::io::Result<Self> {
+        let listener = TcpListener::bind(bind_address)?;
+        Ok(ProxyServer {
             listener: Some(listener),
             stubbed: false,
-        }
+        })
     }
 
     /// Creates a new server instance in stubbed mode.
     /// This mode is used for testing purposes and does not require a real simulator.
+    ///
+    /// # Returns
+    /// A `Result` containing a tuple of (server instance, bound address) or an I/O error.
     #[cfg(test)]
-    pub fn new_stubbed() -> (Self, String) {
+    pub fn new_stubbed() -> std::io::Result<(Self, String)> {
         let bind_address = "127.0.0.1:0";
-        let listener = TcpListener::bind(bind_address).unwrap();
-        let local_addr = listener.local_addr().unwrap().to_string();
-        (
+        let listener = TcpListener::bind(bind_address)?;
+        let local_addr = listener.local_addr()?.to_string();
+        Ok((
             ProxyServer {
                 listener: Some(listener),
                 stubbed: true,
             },
             local_addr,
-        )
+        ))
     }
 
     /// Runs the server, listening for incoming connections.

--- a/src/bridge/remote/tests.rs
+++ b/src/bridge/remote/tests.rs
@@ -24,7 +24,7 @@ fn test_connection_failure() {
 /// Tests enable_rc functionality with stubbed server
 #[test]
 fn test_enable_rc() {
-    let (mut server, server_address) = ProxyServer::new_stubbed();
+    let (mut server, server_address) = ProxyServer::new_stubbed().unwrap();
 
     // Start a server in a separate thread
     let server_thread = thread::spawn(move || {
@@ -45,7 +45,7 @@ fn test_enable_rc() {
 /// Tests disable_rc functionality with stubbed server
 #[test]
 fn test_disable_rc() {
-    let (mut server, server_address) = ProxyServer::new_stubbed();
+    let (mut server, server_address) = ProxyServer::new_stubbed().unwrap();
 
     // Start a server in a separate thread
     let server_thread = thread::spawn(move || {
@@ -65,7 +65,7 @@ fn test_disable_rc() {
 /// Tests reset_aircraft functionality with stubbed server
 #[test]
 fn test_reset_aircraft() {
-    let (mut server, server_address) = ProxyServer::new_stubbed();
+    let (mut server, server_address) = ProxyServer::new_stubbed().unwrap();
 
     // Start a server in a separate thread
     let server_thread = thread::spawn(move || {
@@ -86,7 +86,7 @@ fn test_reset_aircraft() {
 /// Should return a default SimulatorState when in stubbed mode
 #[test]
 fn test_exchange_data() {
-    let (mut server, server_address) = ProxyServer::new_stubbed();
+    let (mut server, server_address) = ProxyServer::new_stubbed().unwrap();
 
     // Start a server in a separate thread
     let server_thread = thread::spawn(move || {


### PR DESCRIPTION
## Summary

- Replace `expect()`/`unwrap()` in TCP client with `Result` propagation
- Handle malformed HTTP responses gracefully instead of panicking
- Track connection pool initialization errors and return meaningful messages
- Make `ProxyServer::new()` return `Result` instead of panicking on bind failure