### PR TITLE
refactor: reorganize module structure

### DIFF
--- a/src/soap_client/mod.rs
+++ b/src/soap_client/mod.rs
@@ -1,3 +1,57 @@
+use std::error::Error;
+
+use crate::BridgeError;
+use crate::decoders::extract_element;
+
 #[cfg(test)]
 pub(crate) mod stub;
 pub(crate) mod tcp;
+
+/// Response from a SOAP request to the RealFlight simulator
+#[derive(Debug)]
+pub(crate) struct SoapResponse {
+    pub status_code: u32,
+    pub body: String,
+}
+
+impl SoapResponse {
+    /// Extract fault message from a failed SOAP response
+    pub fn fault_message(&self) -> String {
+        match extract_element("detail", &self.body) {
+            Some(message) => message,
+            None => "Failed to extract error message".into(),
+        }
+    }
+}
+
+impl From<SoapResponse> for Result<(), BridgeError> {
+    fn from(val: SoapResponse) -> Self {
+        match val.status_code {
+            200 => Ok(()),
+            _ => Err(BridgeError::SoapFault(val.fault_message())),
+        }
+    }
+}
+
+/// Trait for sending SOAP requests to the RealFlight simulator
+pub(crate) trait SoapClient {
+    fn send_action(&self, action: &str, body: &str) -> Result<SoapResponse, Box<dyn Error>>;
+    #[cfg(test)]
+    fn requests(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+/// Encode a SOAP envelope for RealFlight
+pub(crate) fn encode_envelope(action: &str, body: &str) -> String {
+    let mut envelope = String::with_capacity(200 + body.len());
+
+    envelope.push_str("<?xml version='1.0' encoding='UTF-8'?>");
+    envelope.push_str("<soap:Envelope xmlns:soap='http://schemas.xmlsoap.org/soap/envelope/' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>");
+    envelope.push_str("<soap:Body>");
+    envelope.push_str(&format!("<{}>{}</{}>", action, body, action));
+    envelope.push_str("</soap:Body>");
+    envelope.push_str("</soap:Envelope>");
+
+    envelope
+}

--- a/src/soap_client/stub.rs
+++ b/src/soap_client/stub.rs
@@ -6,8 +6,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::bridge::local::{SoapClient, encode_envelope};
-use crate::{SoapResponse, StatisticsEngine};
+use crate::StatisticsEngine;
+
+use super::{SoapClient, SoapResponse, encode_envelope};
 
 #[cfg(test)]
 pub(crate) struct StubSoapClient {

--- a/src/soap_client/tcp.rs
+++ b/src/soap_client/tcp.rs
@@ -16,8 +16,10 @@ use anyhow::{Result, anyhow};
 use crossbeam_channel::{Receiver, Sender, bounded};
 use log::{debug, error};
 
-use crate::bridge::local::{Configuration, SoapClient, encode_envelope};
-use crate::{SoapResponse, StatisticsEngine};
+use crate::StatisticsEngine;
+use crate::bridge::local::Configuration;
+
+use super::{SoapClient, SoapResponse, encode_envelope};
 
 /// Size of header for request body
 const HEADER_LEN: usize = 120;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,6 +23,7 @@ use crate::BridgeError;
 use crate::bridge::local::{Configuration, RealFlightLocalBridge};
 #[cfg(feature = "uom")]
 use crate::decoders::OUNCES_PER_LITER;
+use crate::soap_client::stub::StubSoapClient;
 
 use approx::assert_relative_eq;
 


### PR DESCRIPTION
## Summary
- Move `SoapClient` trait, `SoapResponse`, `encode_envelope` to `soap_client/mod.rs`
- Convert `decode_fault` to `SoapResponse::fault_message()` method
- Remove duplicated code from `lib.rs` and `local.rs`
- Update imports throughout codebase